### PR TITLE
add SomePlugin type that hides existentials to be able to solve plugin typing issues

### DIFF
--- a/library/Neovim/API/Plugin.hs
+++ b/library/Neovim/API/Plugin.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ExistentialQuantification #-}
 {- |
 Module      :  Neovim.API.Plugin
 Description :  Plugin author documentation
@@ -12,6 +12,7 @@ This module describes how a Haksell plugin can be plugged into Neovim.
 -}
 module Neovim.API.Plugin (
     Plugin(..),
+    SomePlugin(..),
     Request(..),
     awaitRequest,
 
@@ -35,6 +36,8 @@ data Plugin r st = Plugin
     , statefulFunctions :: [(Text, TQueue SomeMessage)]
     , services          :: [(r, st, Neovim r st ())]
     }
+
+data SomePlugin = forall r st. SomePlugin (Plugin r st)
 
 awaitRequest :: (MonadIO io) => TQueue SomeMessage -> io Request
 awaitRequest q = do

--- a/library/Neovim/Config.hs
+++ b/library/Neovim/Config.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE RankNTypes #-}
 {- |
 Module      :  Neovim.Config
 Description :  The user editable and compilable configuration
@@ -21,7 +20,7 @@ import           Data.Default      (Default (def))
 import           System.Log        (Priority (..))
 
 data NeovimConfig = Config
-    { plugins      :: forall r st. [IO (Plugin r st)]
+    { plugins      :: [IO SomePlugin]
     , errorMessage :: Maybe String
     -- ^ Used by "Dyre" for storing compilation errors.
     , logOptions   :: Maybe (FilePath, Priority)


### PR DESCRIPTION
As an example, we can now compile @saep's example plugin:

```haskell
{-# LANGUAGE MultiWayIf, OverloadedStrings, RankNTypes #-}

import           Neovim
import           Neovim.API.IPC
import           Neovim.API.Plugin

import           Control.Monad.State
import           System.Log.Logger
import           System.Random

main :: IO ()
main = neovim def
    { logOptions = Just ("nvim-log.txt", DEBUG)
    , plugins    = [ randPlugin ]
    }

randPlugin :: IO SomePlugin
randPlugin = do
    logM "Random" INFO "Starting Rand plugin"
    q <- newTQueueIO
    g <- newStdGen
    return $ SomePlugin $ Plugin
      { name = "Random number generator"
      , functions = []
      , statefulFunctions = [("Random", q)]
      , services = [ ( (), mkStdGen 42, nextRand q ) ]
      }

nextRand :: RandomGen s => TQueue SomeMessage -> Neovim cfg s ()
nextRand q = do
    req <- awaitRequest q
    if | reqMethod req == "Random" -> do
         (r,g) <- random <$> get
         put g
         respond (reqId req) (Right (r :: Int64))
       | True      -> error "damn!"
       | otherwise -> return ()
    nextRand q
``` 