### PR TITLE
fix message type written to message queue

### DIFF
--- a/library/Neovim/RPC/SocketReader.hs
+++ b/library/Neovim/RPC/SocketReader.hs
@@ -108,8 +108,7 @@ handleRequest i method (ObjectArray params) = case fromObject method of
                 reply <- liftIO newEmptyTMVarIO
                 let q = (recipients . customConfig) e
                 atomically' . modifyTVar q $ Map.insert i (now, reply)
-                atomically' . writeTQueue c . SomeMessage
-                    $ FunctionCall m params reply now
+                atomically' . writeTQueue c . SomeMessage $ Request m i params
   where
     writeErrorResponse (Left !err) = (toObject err, ObjectNil)
     writeErrorResponse (Right !res) = (ObjectNil, res)


### PR DESCRIPTION
This was incredibly hard to track down, and it finally fixes the example plugin:

```haskell
{-# LANGUAGE MultiWayIf, OverloadedStrings, RankNTypes #-}

import           Neovim
import           Neovim.API.IPC
import           Neovim.API.Plugin

import           System.Log.Logger
import           System.Random

main :: IO ()
main = neovim def
    { logOptions = Just ("nvim-log.txt", DEBUG)
    , plugins    = [ randPlugin ]
    }

randPlugin :: IO SomePlugin
randPlugin = do
    logM "Random" INFO "Starting Rand plugin"
    q <- newTQueueIO
    g <- newStdGen
    return $ SomePlugin $ Plugin
      { name = "Random number generator"
      , functions = []
      , statefulFunctions = [("Random", q)]
      , services = [ ( (), g, nextRand q ) ]
      }

nextRand :: RandomGen s => TQueue SomeMessage -> Neovim cfg s ()
nextRand q = do
    liftIO $ debugM "Random" "nextRand is running"
    req <- awaitRequest q
    liftIO $ debugM "Random" "nextRand got a request"
    if | reqMethod req == "Random" -> do
         (r,g) <- random <$> get
         put g
         respond (reqId req) (Right (r :: Int64))
       | True      -> error "damn!"
       | otherwise -> error "what what what"
    nextRand q
```

neovim doesn't hang anymore, because we're immediately sending a response. However, I think we're still doing something wrong, because neovim is now giving this error message: `Error converting the call result: Integer value outside the range.` this is probably something related with the protocol implementation. @saep any ideas?