### PR TITLE
refactor EmbeddedRPCSpec to address some problems

### DIFF
--- a/nvim-hs.cabal
+++ b/nvim-hs.cabal
@@ -108,6 +108,7 @@ test-suite hspec
                       , time
                       , transformers
                       , utf8-string
+                      , HUnit
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N
 


### PR DESCRIPTION
* We should use `qa!` to terminate the nvim instance, otherwise it's only closing one window.
* Use `getProcessExitCode` instead of a `TVar`.
* Test nvim return code.

@saep have a look, this fixes some bugs. nvim now always terminates, and we test for return value of the process.