### PR TITLE
Remove the `ExceptT` stack from the `Neovim` type

### DIFF
--- a/library/Neovim/API/Classes.hs
+++ b/library/Neovim/API/Classes.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverlappingInstances       #-}
 {-# LANGUAGE RankNTypes                 #-}
@@ -16,9 +15,6 @@ Stability   :  experimental
 module Neovim.API.Classes
     ( NvimObject(..)
 
-    , NvimFunction
-    , Function
-
     , module Data.Int
     ) where
 
@@ -26,7 +22,6 @@ import           Neovim.API.Context
 
 import           Control.Applicative
 import           Control.Arrow
-import           Control.Monad.Except
 import           Data.ByteString      (ByteString)
 import           Data.Int             (Int64)
 import           Data.Map             (Map)
@@ -46,28 +41,14 @@ import           Data.Text.Encoding   (decodeUtf8, encodeUtf8)
 class NvimObject o where
     toObject :: o -> Object
     fromObjectUnsafe :: Object -> o
-    fromObjectUnsafe o = either
-        (error ("Not the expected object" <> show o))
-        id
-        (fromObject o)
-    fromObject :: Object -> Either String o
+    fromObjectUnsafe o = case fromObject o of
+        Left e -> error $ unwords
+            [ "Not the expected object:"
+            , show o , "(", e, ")"
+            ]
+        Right obj -> obj
+    fromObject :: (NvimObject o) => Object -> Either String o
     fromObject = return . fromObjectUnsafe
-
-newtype Function a = Function { getF :: ExceptT String IO a }
-    deriving ( Monad, Functor, Applicative, MonadIO
-             , MonadError String)
-
-class NvimFunction f where
-    toRPCMethod :: f -> [Object] -> ExceptT String IO Object
-
-instance (NvimObject o) => NvimFunction (Function o) where
-    toRPCMethod f [] = toObject `liftM` getF f
-    toRPCMethod _ _  = error "Error in toRPCMethod"
-
-instance (NvimObject o, NvimFunction f) => NvimFunction (o -> f) where
-    toRPCMethod f ~(x:xs) = case fromObject x of
-        Right o -> toRPCMethod (f $! o) xs
-        Left err -> throwError err
 
 -- Instances for NvimObject {{{1
 instance NvimObject () where
@@ -83,22 +64,30 @@ instance NvimObject Bool where
 instance NvimObject Double where
     toObject                    = ObjectDouble
     fromObject (ObjectDouble o) = return o
+    fromObject (ObjectFloat o)  = return $ realToFrac o
+    fromObject (ObjectInt o)    = return $ fromIntegral o
     fromObject o                = throwError $ "Expected ObjectDouble, but got " <> show o
 
 instance NvimObject Integer where
-    toObject                 = ObjectInt . fromIntegral
-    fromObject (ObjectInt o) = return $ toInteger o
-    fromObject o             = throwError $ "Expected ObjectInt, but got " <> show o
+    toObject                    = ObjectInt . fromIntegral
+    fromObject (ObjectInt o)    = return $ toInteger o
+    fromObject (ObjectDouble o) = return $ round o
+    fromObject (ObjectFloat o)  = return $ round o
+    fromObject o                = throwError $ "Expected ObjectInt, but got " <> show o
 
 instance NvimObject Int64 where
-    toObject                 = ObjectInt
-    fromObject (ObjectInt i) = return i
-    fromObject o             = throwError $ "Expected any Integer value, but got " <> show o
+    toObject                    = ObjectInt
+    fromObject (ObjectInt i)    = return i
+    fromObject (ObjectDouble o) = return $ round o
+    fromObject (ObjectFloat o)  = return $ round o
+    fromObject o                = throwError $ "Expected any Integer value, but got " <> show o
 
 instance NvimObject Int where
-    toObject                 = ObjectInt . fromIntegral
-    fromObject (ObjectInt i) = return $ fromIntegral i
-    fromObject o             = throwError $ "Expected any Integer value, but got " <> show o
+    toObject                    = ObjectInt . fromIntegral
+    fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectDouble o) = return $ round o
+    fromObject (ObjectFloat o)  = return $ round o
+    fromObject o                = throwError $ "Expected any Integer value, but got " <> show o
 
 instance NvimObject [Char] where
     toObject                    = ObjectBinary . U.fromString
@@ -111,6 +100,10 @@ instance NvimObject o => NvimObject [o] where
     fromObject (ObjectArray os) = return $ map fromObjectUnsafe os
     fromObject o                = throwError $ "Expected ObjectArray, but got " <> show o
 
+instance NvimObject o => NvimObject (Maybe o) where
+    toObject = maybe ObjectNil toObject
+    fromObject ObjectNil = return Nothing
+    fromObject o = either throwError (return . Just) $ fromObject o
 
 instance (Ord key, NvimObject key, NvimObject val)
         => NvimObject (Map key val) where

--- a/library/Neovim/API/Classes.hs
+++ b/library/Neovim/API/Classes.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE OverlappingInstances       #-}
 {-# LANGUAGE RankNTypes                 #-}
 {- |
 Module      :  Neovim.API.Classes
@@ -30,6 +29,8 @@ import           Data.MessagePack
 import           Data.Monoid
 import           Data.Text            as Text (Text, unpack)
 import           Data.Traversable
+
+import           Prelude
 
 -- FIXME saep 2014-11-28 Is assuming UTF-8 reasonable?
 import qualified Data.ByteString.UTF8 as U (fromString, toString)
@@ -89,7 +90,7 @@ instance NvimObject Int where
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError $ "Expected any Integer value, but got " <> show o
 
-instance NvimObject [Char] where
+instance {-# OVERLAPS #-} NvimObject [Char] where
     toObject                    = ObjectBinary . U.fromString
     fromObject (ObjectBinary o) = return $ U.toString o
     fromObject (ObjectString o) = return $ Text.unpack o

--- a/library/Neovim/API/Context.hs
+++ b/library/Neovim/API/Context.hs
@@ -65,12 +65,12 @@ runNeovim :: ConfigWrapper r
           -> Neovim r st a
           -> IO (Either String (a, st))
 runNeovim r st a = (try . runReaderT (runStateT a st)) r >>= \case
-    Left err -> let err' = err :: SomeException
-                    -- We want to catch everything here as the plugin provider
-                    -- should not crash.  The error message is propagated to
-                    -- neovim this way. In the future, we may want to handle
-                    -- some kinds of exceptions here manually.
-                in return . Left $ show err'
+    Left e -> let e' = e :: SomeException
+                  -- We want to catch everything here as the plugin provider
+                  -- should not crash.  The error message is propagated to
+                  -- neovim this way. In the future, we may want to handle
+                  -- some kinds of exceptions here manually.
+              in return . Left $ show e'
     Right res -> return $ Right res
 
 data NeovimException = ErrorMessage String

--- a/library/Neovim/API/IPC.hs
+++ b/library/Neovim/API/IPC.hs
@@ -34,7 +34,7 @@ import           Data.Int               (Int64)
 data SomeMessage = forall msg. Message msg => SomeMessage msg
 
 class Typeable message => Message message where
-    fromMessage :: (Message message) => SomeMessage -> Maybe message
+    fromMessage :: SomeMessage -> Maybe message
     fromMessage (SomeMessage message) = cast message
 
 data RPCMessage = FunctionCall Text [Object] (TMVar (Either Object Object)) UTCTime

--- a/library/Neovim/API/Parser.hs
+++ b/library/Neovim/API/Parser.hs
@@ -33,6 +33,8 @@ import           System.IO                (hClose)
 import           System.Process
 import           Text.Parsec              as P
 
+import           Prelude
+
 data NeovimType = SimpleType String
                 | NestedType NeovimType (Maybe Int)
                 | Void

--- a/library/Neovim/API/TH.hs
+++ b/library/Neovim/API/TH.hs
@@ -41,6 +41,8 @@ import           Data.MessagePack
 import           Data.Monoid
 import           Data.Text                (pack)
 
+import           Prelude
+
 -- | Generate the API types and functions provided by @nvim --api-info@.
 --
 -- The provided map allows the use of different Haskell types for the types

--- a/library/Neovim/Main.hs
+++ b/library/Neovim/Main.hs
@@ -44,11 +44,11 @@ optParser = Opt
                 <> short 'a'
                 <> metavar "HOSTNAME"
                 <> help "Connect to the specified host. (requires -p)")
-            <*> (option auto
+            <*> option auto
                 (long "port"
                 <> short 'p'
                 <> metavar "PORT"
-                <> help "Connect to the specified port. (requires -a)")))
+                <> help "Connect to the specified port. (requires -a)"))
     <*> optional (strOption
         (long "unix"
         <> short 'u'
@@ -62,10 +62,10 @@ optParser = Opt
             (long "log-file"
             <> short 'l'
             <> help "File to log to.")
-        <*> (option auto
+        <*> option auto
             (long "log-level"
             <> short 'v'
-            <> help ("Log level. Must be one of: " ++ (unwords . map show) logLevels))))
+            <> help ("Log level. Must be one of: " ++ (unwords . map show) logLevels)))
   where
     -- [minBound..maxBound] would have been nice here.
     logLevels :: [Priority]
@@ -81,7 +81,7 @@ opts = info (helper <*> optParser)
 
 neovim :: NeovimConfig -> IO ()
 neovim = Dyre.wrapMain $ Dyre.defaultParams
-    { Dyre.showError   = \cfg err -> cfg { errorMessage = Just err }
+    { Dyre.showError   = \cfg errM -> cfg { errorMessage = Just errM }
     , Dyre.projectName = "nvim"
     , Dyre.realMain    = realMain
     , Dyre.statusOut   = debugM "Dyre"

--- a/library/Neovim/RPC/Common.hs
+++ b/library/Neovim/RPC/Common.hs
@@ -31,6 +31,8 @@ import           System.IO              (BufferMode (..), Handle, IOMode,
                                          hClose, hSetBuffering)
 import           System.Log.Logger
 
+import           Prelude
+
 type FunctionMap =
     Map Text (Either ([Object] -> Neovim' Object) (TQueue SomeMessage))
 

--- a/library/Neovim/RPC/EventHandler.hs
+++ b/library/Neovim/RPC/EventHandler.hs
@@ -32,6 +32,8 @@ import           Data.MessagePack
 import           Data.Serialize               (encode)
 import           System.IO                    (IOMode (WriteMode))
 
+import           Prelude
+
 -- | This function will establish a connection to the given socket and write
 -- msgpack-rpc requests to it.
 runEventHandler :: SocketType
@@ -71,11 +73,11 @@ eventHandler message = case fromMessage message of
             , toObject fn
             , toObject params
             ]
-    Just (Response i err res) ->
+    Just (Response i e res) ->
         yield . encode $ ObjectArray
             [ toObject (1 :: Int64)
             , ObjectInt i
-            , toObject err
+            , toObject e
             , toObject res
             ]
     Nothing -> return ()

--- a/library/Neovim/RPC/FunctionCall.hs
+++ b/library/Neovim/RPC/FunctionCall.hs
@@ -19,17 +19,19 @@ module Neovim.RPC.FunctionCall (
     respond,
     ) where
 
-import Neovim.API.Context
-import Neovim.API.Classes
-import Neovim.API.IPC
+import           Neovim.API.Classes
+import           Neovim.API.Context
+import           Neovim.API.IPC
 
-import Control.Applicative
-import Control.Monad.Reader as R
-import Data.Monoid
-import Data.Text
-import Data.Time
-import Data.MessagePack
-import Control.Concurrent.STM
+import           Control.Applicative
+import           Control.Concurrent.STM
+import           Control.Monad.Reader   as R
+import           Data.MessagePack
+import           Data.Monoid
+import           Data.Text
+import           Data.Time
+
+import           Prelude
 
 unexpectedException :: String -> err -> a
 unexpectedException fn _ = error $
@@ -96,6 +98,6 @@ respond msgId result = do
         . uncurry (Response msgId) $ toResult result
 
   where
-    toResult (Left err) = (toObject err, toObject ())
+    toResult (Left e) = (toObject e, toObject ())
     toResult (Right r)  = (toObject (), toObject r)
 


### PR DESCRIPTION
This should adress the following issues:
* Needless exception stack as IO already supports exceptions
* Since runNeovim now catches all exceptions, the plugin provider should not
  crash anymore (and possibly cause neovim to hang)