### PR TITLE
[RFC] Add rudementary function generation code

### DIFF
--- a/TestPlugins.hs
+++ b/TestPlugins.hs
@@ -25,7 +25,7 @@ randPlugin = do
     -- don't use this for cryptography!
     let randomNumbers = cycle [42,17,-666] :: [Int16]
     return $ SomePlugin Plugin
-      { exports = []
+      { exports = [Function "Randoom" randoom, Function "const42" const42]
       , statefulExports = [((), randomNumbers, [Function "Random" rf])]
       }
 
@@ -33,8 +33,10 @@ rf :: [Object] -> Neovim cfg [Int16] Object
 rf _ = do
     r <- gets head
     modify tail
-    return $ toObject (fromIntegral r :: Int64)
+    return $ ObjectInt (fromIntegral r)
 
 randoom :: [Object] -> Neovim cfg st Object
 randoom _ = err "Function not supported"
 
+const42 :: [Object] -> Neovim cfg st Object
+const42 _ = return $ ObjectInt 42

--- a/TestPlugins.vim
+++ b/TestPlugins.vim
@@ -34,6 +34,12 @@ endif
 " the execution.
 let randoomValue = rpcrequest(haskellChannel, "Randoom")
 
+let notsorandomvalue = rpcrequest(haskellChannel, "const42")
+if notsorandomvalue != 42
+	echom 'Expected the ultimate answer, but got: ' . notsorandomvalue
+	cq!
+endif
+
 " Everything works, exit normally
 q!
 

--- a/library/Neovim/API/Classes.hs
+++ b/library/Neovim/API/Classes.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE OverlappingInstances       #-}
 {- |
 Module      :  Neovim.API.Classes
 Description :  Type classes used for conversion of msgpack and Haskell types

--- a/library/Neovim/API/Classes.hs
+++ b/library/Neovim/API/Classes.hs
@@ -23,7 +23,7 @@ import           Neovim.API.Context
 import           Control.Applicative
 import           Control.Arrow
 import           Data.ByteString      (ByteString)
-import           Data.Int             (Int64)
+import           Data.Int             (Int16, Int32, Int64)
 import           Data.Map             (Map)
 import qualified Data.Map             as Map
 import           Data.MessagePack
@@ -80,6 +80,20 @@ instance NvimObject Integer where
 instance NvimObject Int64 where
     toObject                    = ObjectInt
     fromObject (ObjectInt i)    = return i
+    fromObject (ObjectDouble o) = return $ round o
+    fromObject (ObjectFloat o)  = return $ round o
+    fromObject o                = throwError $ "Expected any Integer value, but got " <> show o
+
+instance NvimObject Int32 where
+    toObject                    = ObjectInt . fromIntegral
+    fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectDouble o) = return $ round o
+    fromObject (ObjectFloat o)  = return $ round o
+    fromObject o                = throwError $ "Expected any Integer value, but got " <> show o
+
+instance NvimObject Int16 where
+    toObject                    = ObjectInt . fromIntegral
+    fromObject (ObjectInt i)    = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError $ "Expected any Integer value, but got " <> show o

--- a/library/Neovim/API/IPC.hs
+++ b/library/Neovim/API/IPC.hs
@@ -37,14 +37,16 @@ class Typeable message => Message message where
     fromMessage :: SomeMessage -> Maybe message
     fromMessage (SomeMessage message) = cast message
 
-data RPCMessage = FunctionCall Text [Object] (TMVar (Either Object Object)) UTCTime
-                -- ^ Method name, parameters, callback, timestamp
-                | Response !Int64 Object Object
-                -- ^ Responese sent to indicate the result of a function call.
-                --
-                -- * identfier of the message as 'Word32'
-                -- * Error value
-                -- * Result value
+-- | Haskell representation of supported Remote Procedure Call messages.
+data RPCMessage
+    = FunctionCall Text [Object] (TMVar (Either Object Object)) UTCTime
+    -- ^ Method name, parameters, callback, timestamp
+    | Response !Int64 Object Object
+    -- ^ Responese sent to indicate the result of a function call.
+    --
+    -- * identfier of the message as 'Word32'
+    -- * Error value
+    -- * Result value
     deriving (Typeable)
 
 instance Message RPCMessage

--- a/library/Neovim/API/Plugin.hs
+++ b/library/Neovim/API/Plugin.hs
@@ -11,6 +11,7 @@ Stability   :  experimental
 This module describes how a Haksell plugin can be plugged into Neovim.
 -}
 module Neovim.API.Plugin (
+    ExportedFunctionality(..),
     Plugin(..),
     SomePlugin(..),
     Request(..),
@@ -26,6 +27,26 @@ import           Neovim.API.IPC         (Request (..), SomeMessage, fromMessage)
 import           Control.Concurrent.STM
 import           Data.MessagePack
 import           Data.Text
+
+-- | This data type is used in the plugin registration to properly register the
+-- functions.
+data ExportedFunctionality
+    = Function Text ([Object] -> Neovim' Object)
+    -- ^
+    --
+    -- * Name of the function (must start with an uppercase letter)
+    -- * Function to call
+    | Command  Text ([Object] -> Neovim' Object)
+    -- ^
+    --
+    -- * Name of the command (must start with an uppercase letter)
+    -- * Function to call
+    | AutoCmd  Text Text ([Object] -> Neovim' Object)
+    -- ^
+    --
+    -- * Type of autocmd (e.g. FileType)
+    -- * Filter fo the autocmd type
+    -- * Function to call
 
 -- | This data type contains meta information for the plugin manager.
 --

--- a/library/Neovim/API/Plugin.hs
+++ b/library/Neovim/API/Plugin.hs
@@ -52,7 +52,7 @@ data ExportedFunctionality
 --
 data Plugin r st = Plugin
     { name              :: String
-    , functions         :: [(Text, [Object] -> Neovim' Object)]
+    , functions         :: [ExportedFunctionality]
     , statefulFunctions :: [(Text, TQueue SomeMessage)]
     , services          :: [(r, st, Neovim r st ())]
     }

--- a/library/Neovim/API/Plugin.hs
+++ b/library/Neovim/API/Plugin.hs
@@ -124,7 +124,7 @@ registerStatefulFunctionality evq m (r, st, fs) = do
                     Left e -> let e' = e :: SomeException
                               in return . Left $ show e'
                     Right res -> return $ Right res
-                respond (reqId req) res
+                respond req res
             Nothing -> return ()
         listeningThread q
 

--- a/library/Neovim/API/Plugin.hs
+++ b/library/Neovim/API/Plugin.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE LambdaCase                #-}
 {- |
 Module      :  Neovim.API.Plugin
 Description :  Plugin author documentation
@@ -12,6 +13,8 @@ This module describes how a Haksell plugin can be plugged into Neovim.
 -}
 module Neovim.API.Plugin (
     ExportedFunctionality(..),
+    registerStatefulFunctionalities,
+    updateFunctionMap,
     Plugin(..),
     SomePlugin(..),
     Request(..),
@@ -22,26 +25,34 @@ module Neovim.API.Plugin (
     ) where
 
 import           Neovim.API.Context
-import           Neovim.API.IPC         (Request (..), SomeMessage, fromMessage)
+import           Neovim.API.IPC           (Request (..), SomeMessage,
+                                           fromMessage)
+import           Neovim.RPC.Common
+import           Neovim.RPC.FunctionCall
 
+import           Control.Applicative
+import           Control.Concurrent       (ThreadId, forkIO)
 import           Control.Concurrent.STM
+import           Control.Exception.Lifted (SomeException (..), try)
+import           Control.Monad            (foldM, void)
+import qualified Data.Map                 as Map
 import           Data.MessagePack
-import           Data.Text
+import           Data.Text                (Text)
 
 -- | This data type is used in the plugin registration to properly register the
 -- functions.
-data ExportedFunctionality
-    = Function Text ([Object] -> Neovim' Object)
+data ExportedFunctionality r st
+    = Function Text ([Object] -> Neovim r st Object)
     -- ^
     --
     -- * Name of the function (must start with an uppercase letter)
     -- * Function to call
-    | Command  Text ([Object] -> Neovim' Object)
+    | Command  Text ([Object] -> Neovim r st Object)
     -- ^
     --
     -- * Name of the command (must start with an uppercase letter)
     -- * Function to call
-    | AutoCmd  Text Text ([Object] -> Neovim' Object)
+    | AutoCmd  Text Text ([Object] -> Neovim r st Object)
     -- ^
     --
     -- * Type of autocmd (e.g. FileType)
@@ -51,13 +62,73 @@ data ExportedFunctionality
 -- | This data type contains meta information for the plugin manager.
 --
 data Plugin r st = Plugin
-    { name              :: String
-    , functions         :: [ExportedFunctionality]
-    , statefulFunctions :: [(Text, TQueue SomeMessage)]
-    , services          :: [(r, st, Neovim r st ())]
+    { exports         :: [ExportedFunctionality () ()]
+    , statefulExports :: [(r, st, [ExportedFunctionality r  st])]
     }
 
 data SomePlugin = forall r st. SomePlugin (Plugin r st)
+
+updateFunctionMap
+    :: TQueue SomeMessage
+    -> FunctionMap
+    -> [ExportedFunctionality () ()]
+    -> IO FunctionMap
+updateFunctionMap evq = foldM updateMap
+  where
+    updateMap m = \case
+        Function n f  -> return $ Map.insert n (Left f) m
+        Command  n f  -> return $ Map.insert n (Left f) m
+        AutoCmd _ _ _ -> error "TODO register autocmds"
+
+registerStatefulFunctionalities
+    :: TQueue SomeMessage
+    -> FunctionMap
+    -> [(r,st, [ExportedFunctionality r st])]
+    -> IO ([ThreadId], FunctionMap)
+registerStatefulFunctionalities evq funMap = foldM f ([], funMap)
+  where
+    f (tids,m) e = (\(tid,m') -> (tid:tids,m'))
+        <$> registerStatefulFunctionality evq m e
+
+-- | Create a listening thread for events and add update the 'FunctionMap' with
+-- the corresponding 'TQueue's (i.e. communication channels).
+registerStatefulFunctionality
+    :: TQueue SomeMessage -- ^ Global event queue
+    -> FunctionMap        -- ^ Function map to update
+    -> (r, st, [ExportedFunctionality r st])
+    -> IO (ThreadId, FunctionMap)
+registerStatefulFunctionality evq m (r, st, fs) = do
+    q <- newTQueueIO
+    tid <- forkIO . void $ runNeovim (ConfigWrapper evq r) st (listeningThread q)
+    return $ (tid, foldr (updateMap q) m fs)
+  where
+    updateMap q = \case
+        Function fn _ -> Map.insert fn (Right q)
+        Command  fn _ -> Map.insert fn (Right q)
+        AutoCmd _ _ _ -> error "Not implemented." -- FIXME
+
+    functionRoutes = foldr updateRoute Map.empty fs
+    updateRoute = \case
+        Function fn f -> Map.insert fn f
+        Command  fn f -> Map.insert fn f
+        AutoCmd _ _ _ -> error "Not implemented." -- FIXME
+
+    listeningThread q = do
+        msg <- liftIO . atomically $ readTQueue q
+        let funAndRequest = do req <- fromMessage msg
+                               f <- Map.lookup (reqMethod req) functionRoutes
+                               return (f,req)
+        case funAndRequest of
+            Just (f,req) -> do
+                res <- (try . f . reqArgs) req >>= \case
+                    Left e -> let e' = e :: SomeException
+                              in return . Left $ show e'
+                    Right res -> return $ Right res
+                respond (reqId req) res
+            Nothing -> return ()
+        listeningThread q
+
+
 
 awaitRequest :: (MonadIO io) => TQueue SomeMessage -> io Request
 awaitRequest q = do

--- a/library/Neovim/API/TH.hs
+++ b/library/Neovim/API/TH.hs
@@ -281,6 +281,7 @@ functionImplementation functionName = do
 
     determineNumberOfArguments :: Type -> Int
     determineNumberOfArguments ft = case ft of
+        ForallT _ _ t -> determineNumberOfArguments t
         AppT (AppT ArrowT _) r -> 1 + determineNumberOfArguments r
         _ -> 0
     -- \args -> case args of ...

--- a/library/Neovim/API/TH.hs
+++ b/library/Neovim/API/TH.hs
@@ -234,7 +234,7 @@ customTypeInstance typeName nis =
 -- \args -> case args of
 --     [x,y] -> case pure add <*> fromObject x <*> fromObject y of
 --         Left e -> err $ "Wrong type of arguments for add: " ++ e
---         Right action -> action
+--         Right action -> toObject <$> action
 --     _ -> err $ "Wrong number of arguments for add: " ++ show xs
 -- @
 --
@@ -280,7 +280,7 @@ function functionName = do
     successfulEvaluation :: Q Match
     successfulEvaluation = newName "action" >>= \action ->
         match (conP (mkName "Right") [varP action])
-              (normalB (varE action))
+              (normalB [|toObject <$> $(varE action)|])
               []
     failedEvaluation :: Q Match
     failedEvaluation = newName "e" >>= \e ->

--- a/library/Neovim/Config.hs
+++ b/library/Neovim/Config.hs
@@ -21,6 +21,9 @@ import           System.Log        (Priority (..))
 
 data NeovimConfig = Config
     { plugins      :: [IO SomePlugin]
+    -- ^ The list of plugins. The IO type inside the list allows the plugin
+    -- author to run some arbitrary startup code before creating a value of
+    -- type 'SomePlugin'.
     , errorMessage :: Maybe String
     -- ^ Used by "Dyre" for storing compilation errors.
     , logOptions   :: Maybe (FilePath, Priority)

--- a/library/Neovim/RPC/FunctionCall.hs
+++ b/library/Neovim/RPC/FunctionCall.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {- |
 Module      :  Neovim.RPC.FunctionCall
 Description :  Functions for calling functions
@@ -92,11 +93,11 @@ wait' :: (Functor io, MonadIO io) => io (STM result) -> io ()
 wait' = void . (=<<) atomically'
 
 -- | Send the result back to the neovim instance.
-respond :: (NvimObject result) => Int64 -> Either String result -> Neovim r st ()
-respond msgId result = do
+respond :: (NvimObject result) => Request -> Either String result -> Neovim r st ()
+respond Request{..} result = do
     q <- eventQueue
     atomically' . writeTQueue q . SomeMessage
-        . uncurry (Response msgId) $ toResult result
+        . uncurry (Response reqId) $ toResult result
 
   where
     toResult (Left e) = (toObject e, toObject ())

--- a/test-suite/Neovim/API/THSpec.hs
+++ b/test-suite/Neovim/API/THSpec.hs
@@ -34,7 +34,7 @@ isNeovimException _ = True
 spec :: Spec
 spec = do
   describe "calling function without an argument" $ do
-    let Function fname testFun = $(function 'testFunction0) "testFunction0"
+    let Function fname testFun = $(function  "testFunction0" 'testFunction0)
     it "should have the same name" $ do
         fname `shouldBe` "testFunction0"
     it "should return the consant value" $ do
@@ -42,8 +42,8 @@ spec = do
     it "should fail if supplied an argument" $ do
         call testFun [ObjectNil] `shouldThrow` isNeovimException
 
-  describe "calling testFunction" $ do
-    let Function fname testFun = $(function 'testFunction2) "testFunction2"
+  describe "calling testFunction with two arguments" $ do
+    let Function fname testFun = $(function' 'testFunction2)
     it "should have the same name" $ do
         fname `shouldBe` "testFunction2"
     it "should return 2 for proper arguments" $ do
@@ -55,8 +55,13 @@ spec = do
     it "should cast arguments to similar types" $ do
       call testFun [ObjectString "ignored", ObjectFloat 42] `shouldReturn` ObjectDouble 2
 
+  describe "generating a command from the two argument test function" $ do
+      let Command fname testFun = $(command' 'testFunction2)
+      it "should capitalize the first character" $ do
+        fname `shouldBe` "TestFunction2"
+
   describe "calling test function with a map argument" $ do
-      let Command cname testFun = $(command 'testFunctionMap) "testFunctionMap"
+      let Command cname testFun = $(command "TestFunctionMap" 'testFunctionMap)
       it "should capitalize the first letter" $ do
           cname `shouldBe` "TestFunctionMap"
       it "should fail for the wrong number of arguments" $ do

--- a/test-suite/Neovim/API/THSpec.hs
+++ b/test-suite/Neovim/API/THSpec.hs
@@ -16,11 +16,16 @@ import Test.Hspec
 import Control.Applicative
 import Control.Concurrent.STM
 
-call :: NvimObject a => ([Object] -> Neovim () () a) -> [Object]
-     -> IO (Either String a)
+call :: ([Object] -> Neovim () () Object) -> [Object]
+     -> IO Object
 call f args = do
     cfg <- ConfigWrapper <$> newTQueueIO <*> return ()
-    fst <$> runNeovim cfg () (f args)
+    res <- fmap fst <$> runNeovim cfg () (f args)
+    case res of
+        Right x -> return x
+        Left e -> throw $ ErrorMessage e
+
+
 
 isNeovimException :: NeovimException -> Bool
 isNeovimException _ = True
@@ -30,20 +35,20 @@ spec = do
   describe "calling function without an argument" $ do
     let testFun = $(function 'testFunction0)
     it "should return the consant value" $ do
-      call testFun [] `shouldReturn` Right 42
+      call testFun [] `shouldReturn` ObjectInt 42
     it "should fail if supplied an argument" $ do
         call testFun [ObjectNil] `shouldThrow` isNeovimException
 
   describe "calling testFunction" $ do
     let testFun = $(function 'testFunction2)
     it "should return 2 for proper arguments" $ do
-      call testFun [ObjectBinary "ignored", ObjectInt 42] `shouldReturn` Right 2
+      call testFun [ObjectBinary "ignored", ObjectInt 42] `shouldReturn` ObjectDouble 2
     it "should throw an exception for the wrong number of arguments" $ do
       call testFun [] `shouldThrow` isNeovimException
     it "should throw an exception for incompatible types" $ do
       call testFun [ObjectBinary "ignored", ObjectNil] `shouldThrow` isNeovimException
     it "should cast arguments to similar types" $ do
-      call testFun [ObjectString "ignored", ObjectFloat 42] `shouldReturn` Right 2
+      call testFun [ObjectString "ignored", ObjectFloat 42] `shouldReturn` ObjectDouble 2
 
   describe "calling test function with a map argument" $ do
       let testFun = $(function 'testFunctionMap)
@@ -53,8 +58,7 @@ spec = do
         call testFun [ObjectInt 7, ObjectString "FOO"] `shouldThrow` isNeovimException
       it "should return Nothing for an empty map" $ do
           call testFun [toObject (Map.empty :: Map.Map String Int), ObjectString "FOO"]
-            `shouldReturn` Right Nothing
+            `shouldReturn` ObjectNil
       it "should return just the value for the singletion entry" $ do
           call testFun [toObject (Map.singleton "FOO" 7 :: Map.Map String Int), ObjectString "FOO"]
-            `shouldReturn` Right (Just 7)
-
+            `shouldReturn` ObjectInt 7

--- a/test-suite/Neovim/API/THSpec.hs
+++ b/test-suite/Neovim/API/THSpec.hs
@@ -13,6 +13,7 @@ import Neovim.API.Plugin
 import qualified Data.Map as Map
 
 import Test.Hspec
+import Test.QuickCheck
 
 import Control.Applicative
 import Control.Concurrent.STM
@@ -59,6 +60,13 @@ spec = do
       let Command fname testFun = $(command' 'testFunction2)
       it "should capitalize the first character" $ do
         fname `shouldBe` "TestFunction2"
+
+  describe "generating the test successor functions" $ do
+      let Function fname testFun = $(function' 'testSucc)
+      it "should be named testSucc" $ do
+          fname `shouldBe` "testSucc"
+      it "should return the old value + 1" $ property $ do
+          \x -> call testFun [ObjectInt x] `shouldReturn` ObjectInt (x+1)
 
   describe "calling test function with a map argument" $ do
       let Command cname testFun = $(command "TestFunctionMap" 'testFunctionMap)

--- a/test-suite/Neovim/API/THSpec.hs
+++ b/test-suite/Neovim/API/THSpec.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Neovim.API.THSpec
+    where
+
+import Neovim.API.THSpecFunctions
+
+import Neovim.API.Classes
+import Neovim.API.TH
+import Neovim.API.Context
+
+import qualified Data.Map as Map
+
+import Test.Hspec
+
+import Control.Applicative
+import Control.Concurrent.STM
+
+call :: NvimObject a => ([Object] -> Neovim () () a) -> [Object]
+     -> IO (Either String a)
+call f args = do
+    cfg <- ConfigWrapper <$> newTQueueIO <*> return ()
+    fst <$> runNeovim cfg () (f args)
+
+isNeovimException :: NeovimException -> Bool
+isNeovimException _ = True
+
+spec :: Spec
+spec = do
+  describe "calling function without an argument" $ do
+    let testFun = $(function 'testFunction0)
+    it "should return the consant value" $ do
+      call testFun [] `shouldReturn` Right 42
+    it "should fail if supplied an argument" $ do
+        call testFun [ObjectNil] `shouldThrow` isNeovimException
+
+  describe "calling testFunction" $ do
+    let testFun = $(function 'testFunction2)
+    it "should return 2 for proper arguments" $ do
+      call testFun [ObjectBinary "ignored", ObjectInt 42] `shouldReturn` Right 2
+    it "should throw an exception for the wrong number of arguments" $ do
+      call testFun [] `shouldThrow` isNeovimException
+    it "should throw an exception for incompatible types" $ do
+      call testFun [ObjectBinary "ignored", ObjectNil] `shouldThrow` isNeovimException
+    it "should cast arguments to similar types" $ do
+      call testFun [ObjectString "ignored", ObjectFloat 42] `shouldReturn` Right 2
+
+  describe "calling test function with a map argument" $ do
+      let testFun = $(function 'testFunctionMap)
+      it "should fail for the wrong number of arguments" $ do
+        call testFun [] `shouldThrow` isNeovimException
+      it "should fail for the wrong type of arguments" $ do
+        call testFun [ObjectInt 7, ObjectString "FOO"] `shouldThrow` isNeovimException
+      it "should return Nothing for an empty map" $ do
+          call testFun [toObject (Map.empty :: Map.Map String Int), ObjectString "FOO"]
+            `shouldReturn` Right Nothing
+      it "should return just the value for the singletion entry" $ do
+          call testFun [toObject (Map.singleton "FOO" 7 :: Map.Map String Int), ObjectString "FOO"]
+            `shouldReturn` Right (Just 7)
+

--- a/test-suite/Neovim/API/THSpec.hs
+++ b/test-suite/Neovim/API/THSpec.hs
@@ -8,6 +8,7 @@ import Neovim.API.THSpecFunctions
 import Neovim.API.Classes
 import Neovim.API.TH
 import Neovim.API.Context
+import Neovim.API.Plugin
 
 import qualified Data.Map as Map
 
@@ -33,14 +34,18 @@ isNeovimException _ = True
 spec :: Spec
 spec = do
   describe "calling function without an argument" $ do
-    let testFun = $(function 'testFunction0)
+    let Function fname testFun = $(function 'testFunction0) "testFunction0"
+    it "should have the same name" $ do
+        fname `shouldBe` "testFunction0"
     it "should return the consant value" $ do
       call testFun [] `shouldReturn` ObjectInt 42
     it "should fail if supplied an argument" $ do
         call testFun [ObjectNil] `shouldThrow` isNeovimException
 
   describe "calling testFunction" $ do
-    let testFun = $(function 'testFunction2)
+    let Function fname testFun = $(function 'testFunction2) "testFunction2"
+    it "should have the same name" $ do
+        fname `shouldBe` "testFunction2"
     it "should return 2 for proper arguments" $ do
       call testFun [ObjectBinary "ignored", ObjectInt 42] `shouldReturn` ObjectDouble 2
     it "should throw an exception for the wrong number of arguments" $ do
@@ -51,7 +56,9 @@ spec = do
       call testFun [ObjectString "ignored", ObjectFloat 42] `shouldReturn` ObjectDouble 2
 
   describe "calling test function with a map argument" $ do
-      let testFun = $(function 'testFunctionMap)
+      let Command cname testFun = $(command 'testFunctionMap) "testFunctionMap"
+      it "should capitalize the first letter" $ do
+          cname `shouldBe` "TestFunctionMap"
       it "should fail for the wrong number of arguments" $ do
         call testFun [] `shouldThrow` isNeovimException
       it "should fail for the wrong type of arguments" $ do

--- a/test-suite/Neovim/API/THSpecFunctions.hs
+++ b/test-suite/Neovim/API/THSpecFunctions.hs
@@ -13,3 +13,5 @@ testFunction2 _ _ = return 2
 testFunctionMap :: Map.Map String Int -> String -> Neovim' (Maybe Int)
 testFunctionMap m k = return $ Map.lookup k m
 
+testSucc :: Int -> Neovim r st Int
+testSucc = return . succ

--- a/test-suite/Neovim/API/THSpecFunctions.hs
+++ b/test-suite/Neovim/API/THSpecFunctions.hs
@@ -1,0 +1,15 @@
+module Neovim.API.THSpecFunctions
+    where
+
+import Neovim.API.Context
+import qualified Data.Map as Map
+
+testFunction0 :: Neovim' Int
+testFunction0 = return 42
+
+testFunction2 :: String -> Int -> Neovim' Double
+testFunction2 _ _ = return 2
+
+testFunctionMap :: Map.Map String Int -> String -> Neovim' (Maybe Int)
+testFunctionMap m k = return $ Map.lookup k m
+


### PR DESCRIPTION
I started to write some Template Haskell, so that one is able to write (simple) stateless functions in a normal Haskell manner. This addresses the points made in #12 which should be discussed further.

The drawbacks I have found are the following:
* The types cannot be generic, unless you use `Object` directly. This means that you may have to put a type annotation on the function.
* You may have to define those functions in a different module than the one you are using the `function` splice.
* Variadic functions are not really supported, you have to at least supply a `nil` value as an argument and use `Maybe` around the arguments type. A the same time, heterogeneous lists are not supported as arguments (and maybe they shouldn't be anyway).